### PR TITLE
Ensure snake_case boolean names

### DIFF
--- a/src/client/control.zig
+++ b/src/client/control.zig
@@ -43,7 +43,7 @@ pub const Control = struct {
     model: core.Model,
     view: View,
     client: network.Client,
-    snapshotRequired: bool = true,
+    should_request_snapshot: bool = true,
 
     pub fn init(allocator: *std.mem.Allocator) Control {
         const control = Control{
@@ -97,9 +97,9 @@ pub const Control = struct {
             return;
         }
 
-        if (self.snapshotRequired) {
+        if (self.should_request_snapshot) {
             self.client.submit(network.SnapshotRequestMessage.init());
-            self.snapshotRequired = false;
+            self.should_request_snapshot = false;
         }
 
         // Receive messages

--- a/src/editor/control.zig
+++ b/src/editor/control.zig
@@ -168,7 +168,7 @@ const SelectionState = struct {
 };
 
 const TransformState = struct {
-    dragging: bool,
+    is_dragging: bool,
     //origin: Vec2,
     start_mouse: Vec2,
     start_position: Vec2,
@@ -293,7 +293,7 @@ pub fn renderPrefab(prefab: *const Prefab, tex_cache: *TextureCache, allocator: 
 pub const Control = struct {
     allocator: *std.mem.Allocator,
     model: core.Model,
-    snapshotRequired: bool = true,
+    should_request_snapshot: bool = true,
 
     arena_allocator: std.heap.ArenaAllocator = std.heap.ArenaAllocator.init(std.heap.page_allocator),
 
@@ -491,7 +491,7 @@ pub const Control = struct {
                 if (self.editor.selection.selected_part) |i| {
                     const part = cur.parts_list.items[i];
                     self.editor.transform = TransformState{
-                        .dragging = true,
+                        .is_dragging = true,
                         .start_mouse = mouse_world,
                         .start_position = part.position,
                     };
@@ -501,7 +501,7 @@ pub const Control = struct {
 
         if (rl.isMouseButtonDown(rl.MouseButton.left)) {
             if (self.editor.transform) |t| {
-                if (t.dragging) {
+                if (t.is_dragging) {
                     if (self.current) |*cur| {
                         if (self.editor.selection.selected_part) |i| {
                             var part = &cur.parts_list.items[i];
@@ -532,7 +532,7 @@ pub const Control = struct {
             }
         } else {
             if (self.editor.transform) |*t| {
-                t.dragging = false;
+                t.is_dragging = false;
             }
         }
     }

--- a/src/master/quadtree.zig
+++ b/src/master/quadtree.zig
@@ -153,10 +153,10 @@ const Rect = struct {
 
 //TODO to utils
 pub const DirectionSet = packed struct {
-    north: bool = false,
-    south: bool = false,
-    east: bool = false,
-    west: bool = false,
+    has_north: bool = false,
+    has_south: bool = false,
+    has_east: bool = false,
+    has_west: bool = false,
 
     pub fn empty() DirectionSet {
         return .{};
@@ -170,33 +170,33 @@ pub const DirectionSet = packed struct {
 
     pub fn set(self: *DirectionSet, dir: Direction, value: bool) void {
         switch (dir) {
-            .North => self.north = value,
-            .South => self.south = value,
-            .East => self.east = value,
-            .West => self.west = value,
+            .North => self.has_north = value,
+            .South => self.has_south = value,
+            .East => self.has_east = value,
+            .West => self.has_west = value,
 
             .NorthEast => {
-                self.north = value;
-                self.east = value;
+                self.has_north = value;
+                self.has_east = value;
             },
             .NorthWest => {
-                self.north = value;
-                self.west = value;
+                self.has_north = value;
+                self.has_west = value;
             },
             .SouthEast => {
-                self.south = value;
-                self.east = value;
+                self.has_south = value;
+                self.has_east = value;
             },
             .SouthWest => {
-                self.south = value;
-                self.west = value;
+                self.has_south = value;
+                self.has_west = value;
             },
         }
     }
 };
 
 const Neightbours = struct {
-    valid: bool = false,
+    is_valid: bool = false,
     north: *std.ArrayList(ServerId),
     ne: ServerId,
     east: *std.ArrayList(ServerId),

--- a/src/shared/network/message.zig
+++ b/src/shared/network/message.zig
@@ -536,7 +536,7 @@ pub const NoticeMessage = struct {
     pub fn write(self: NoticeMessage, writer: anytype) void {
         _ = self;
         _ = writer;
-        //writer.print("VersionResult: {d}", .{self.match}) catch unreachable;
+        //writer.print("VersionResult: {d}", .{self.is_match}) catch unreachable;
     }
 };
 
@@ -686,7 +686,7 @@ pub const KickMessage = struct {
     pub fn write(self: KickMessage, writer: anytype) void {
         _ = self;
         _ = writer;
-        //writer.print("VersionResult: {d}", .{self.match}) catch unreachable;
+        //writer.print("VersionResult: {d}", .{self.is_match}) catch unreachable;
     }
 };
 
@@ -791,23 +791,23 @@ pub const VersionCheckMessage = struct {
     pub fn write(self: VersionCheckMessage, writer: anytype) void {
         _ = self;
         _ = writer;
-        //writer.print("VersionResult: {d}", .{self.match}) catch unreachable;
+        //writer.print("VersionResult: {d}", .{self.is_match}) catch unreachable;
     }
 };
 
 pub const VersionResultMessage = struct {
     allocator: *std.mem.Allocator,
-    match: bool,
+    is_match: bool,
     version: []const u8,
     message: []const u8,
 
-    pub fn init(allocator: *std.mem.Allocator, match: bool, version: []const u8, message: []const u8) Message {
+    pub fn init(allocator: *std.mem.Allocator, is_match: bool, version: []const u8, message: []const u8) Message {
         const dup_version = allocator.dupe(u8, version) catch unreachable;
         const dup_message = allocator.dupe(u8, message) catch unreachable;
 
         const vers = VersionResultMessage{
             .allocator = allocator,
-            .match = match,
+            .is_match = is_match,
             .version = dup_version,
             .message = dup_message,
         };
@@ -821,32 +821,34 @@ pub const VersionResultMessage = struct {
     }
 
     fn serialize(self: VersionResultMessage, writer: anytype) void {
-        serial.serializeBool(writer, self.match);
+        serial.serializeBool(writer, self.is_match);
         serial.serializeText(writer, self.version);
         serial.serializeText(writer, self.message);
     }
 
     fn deserialize(reader: anytype, allocator: *std.mem.Allocator) VersionResultMessage {
-        const match = serial.deserializeBool(reader);
+        const is_match = serial.deserializeBool(reader);
         const version = serial.deserializeText(reader, allocator);
         const message = serial.deserializeText(reader, allocator);
-        return init(allocator, match, version, message).VersionResult;
+        return init(allocator, is_match, version, message).VersionResult;
     }
 
     pub fn write(self: VersionResultMessage, writer: anytype) void {
         _ = self;
         _ = writer;
-        //writer.print("VersionResult: {d}", .{self.match}) catch unreachable;
+        //writer.print("VersionResult: {d}", .{self.is_match}) catch unreachable;
     }
 };
 
 pub const AuthChallengeMessage = struct {
     auth_id: u64,
+    is_success: bool,
     //TODO
 
-    pub fn init(auth_id: u64) Message {
+    pub fn init(auth_id: u64, is_success: bool) Message {
         const auth = AuthChallengeMessage{
             .auth_id = auth_id,
+            .is_success = is_success,
         };
 
         return Message{ .AuthChallenge = auth };
@@ -857,12 +859,13 @@ pub const AuthChallengeMessage = struct {
     }
 
     fn serialize(self: AuthChallengeMessage, writer: anytype) void {
-        serial.serializeU64(writer, self.success);
+        serial.serializeU64(writer, self.is_success);
     }
 
     fn deserialize(reader: anytype) AuthChallengeMessage {
         const auth_id = serial.deserializeU64(reader);
-        return init(auth_id).AuthChallenge;
+        const is_success = serial.deserializeBool(reader);
+        return init(auth_id, is_success).AuthChallenge;
     }
 
     pub fn write(self: AuthChallengeMessage, writer: anytype) void {
@@ -906,12 +909,12 @@ pub const AuthResultMessage = struct {
 
 pub const AuthResponseMessage = struct {
     auth_id: u64,
-    success: bool,
+    is_success: bool,
 
-    pub fn init(auth_id: u64, success: bool) Message {
+    pub fn init(auth_id: u64, is_success: bool) Message {
         const auth = AuthResponseMessage{
             .auth_id = auth_id,
-            .success = success,
+            .is_success = is_success,
         };
 
         return Message{ .AuthResponse = auth };
@@ -923,19 +926,19 @@ pub const AuthResponseMessage = struct {
 
     fn serialize(self: AuthResponseMessage, writer: anytype) void {
         serial.serializeU64(writer, self.auth_id);
-        serial.serializeBool(writer, self.success);
+        serial.serializeBool(writer, self.is_success);
     }
 
     fn deserialize(reader: anytype) AuthResponseMessage {
         const auth_id = serial.deserializeU64(reader);
-        const success = serial.deserializeBool(reader);
-        return init(auth_id, success).AuthResponse;
+        const is_success = serial.deserializeBool(reader);
+        return init(auth_id, is_success).AuthResponse;
     }
 
     pub fn write(self: AuthResponseMessage, writer: anytype) void {
         _ = self;
         _ = writer;
-        //writer.print("AuthResponse: {d}", .{self.success}) catch unreachable;
+        //writer.print("AuthResponse: {d}", .{self.is_success}) catch unreachable;
     }
 };
 

--- a/src/shared/network/message.zig
+++ b/src/shared/network/message.zig
@@ -842,13 +842,11 @@ pub const VersionResultMessage = struct {
 
 pub const AuthChallengeMessage = struct {
     auth_id: u64,
-    is_success: bool,
     //TODO
 
-    pub fn init(auth_id: u64, is_success: bool) Message {
+    pub fn init(auth_id: u64) Message {
         const auth = AuthChallengeMessage{
             .auth_id = auth_id,
-            .is_success = is_success,
         };
 
         return Message{ .AuthChallenge = auth };
@@ -864,8 +862,7 @@ pub const AuthChallengeMessage = struct {
 
     fn deserialize(reader: anytype) AuthChallengeMessage {
         const auth_id = serial.deserializeU64(reader);
-        const is_success = serial.deserializeBool(reader);
-        return init(auth_id, is_success).AuthChallenge;
+        return init(auth_id).AuthChallenge;
     }
 
     pub fn write(self: AuthChallengeMessage, writer: anytype) void {

--- a/src/shared/network/server.zig
+++ b/src/shared/network/server.zig
@@ -53,7 +53,7 @@ const TimedBatch = struct {
 pub const Server = struct {
     allocator: *std.mem.Allocator,
     socket: net.Socket = undefined,
-    opened: bool = false,
+    is_opened: bool = false,
     clients: std.AutoHashMap(u64, net.Socket),
     batches: std.AutoHashMap(u64, Batch),
     batchesToSend: std.ArrayList(TimedBatch),
@@ -105,7 +105,7 @@ pub const Server = struct {
 
         log.info("server listening on port {}", .{port});
 
-        self.opened = true;
+        self.is_opened = true;
     }
 
     pub fn close(self: *Server) void {
@@ -119,7 +119,7 @@ pub const Server = struct {
 
         self.clients.deinit();
 
-        self.opened = false;
+        self.is_opened = false;
     }
 
     pub fn accept(self: *Server) void {


### PR DESCRIPTION
## Summary
- rename boolean fields using `is_`, `has_`, or `should_` prefixes with snake_case
- update initialization and usage accordingly

## Testing
- `zig version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68809886ead883288342b46603ab0b87