### PR TITLE
Fix rotation and QuadInfo serialization

### DIFF
--- a/src/extra/network/message.zig
+++ b/src/extra/network/message.zig
@@ -274,13 +274,13 @@ pub const QuadInfoMessage = struct {
     }
 
     fn serialize(self: QuadInfoMessage, writer: anytype) void {
-        serial.serializeU64(writer, self.id);
+        serial.serializeU64(writer, self.quad);
         serial.serializeF32(writer, self.pressure);
     }
     fn deserialize(reader: anytype) QuadInfoMessage {
-        const id = serial.deserializeU64(reader);
+        const quad = serial.deserializeU64(reader);
         const pressure = serial.deserializeF32(reader);
-        return init(id, pressure).QuadInfo;
+        return init(quad, pressure).QuadInfo;
     }
 
     pub fn write(self: QuadInfoMessage, writer: anytype) void {

--- a/src/util/geometry/vec2.zig
+++ b/src/util/geometry/vec2.zig
@@ -109,8 +109,8 @@ pub const Vec2 = struct {
     }
 
     pub fn rotate(v: Vec2, angle: Angle) Vec2 {
-        const cos = @cos(angle.toDegrees());
-        const sin = @sin(angle.toDegrees());
+        const cos = @cos(angle.toRadians());
+        const sin = @sin(angle.toRadians());
         return .{
             .x = v.x * cos - v.y * sin,
             .y = v.x * sin + v.y * cos,

--- a/src/util/ziggy.zig
+++ b/src/util/ziggy.zig
@@ -35,9 +35,6 @@ pub fn load(allocator: std.mem.Allocator, path: []const u8, T: type) !?T {
     const stat = file.stat() catch unreachable;
     file.seekTo(0) catch unreachable;
 
-    const raw = allocator.alloc(u8, stat.size) catch unreachable;
-    defer allocator.free(raw);
-
     const buffer = file.readToEndAlloc(allocator, stat.size) catch unreachable;
     defer allocator.free(buffer);
 


### PR DESCRIPTION
## Summary
- avoid unused buffer allocation when loading ziggy
- rotate Vec2 using radians, not degrees
- fix QuadInfoMessage serialization/deserialization

## Testing
- `zig fmt src/util/ziggy.zig src/util/geometry/vec2.zig src/extra/network/message.zig` *(fails: `bash: command not found: zig`)*

------
https://chatgpt.com/codex/tasks/task_e_68815c5a78e483288d7ef08959fd9978