### PR TITLE
Implement prefab manifest using file paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ zig-out/
 
 # kde
 .directory
+zig-linux-x86_64-0.14.0.tar.xz
+zig-linux-x86_64-0.14.0/

--- a/src/editor/view/view.zig
+++ b/src/editor/view/view.zig
@@ -43,25 +43,23 @@ pub const View = struct {
     cache: TextureCache,
     camera: rl.Camera2D,
 
-    //TODO[MISSING] make dynamic
-    const screen_width = 1920 / 2;
-    const screen_height = 1080 / 2;
+    const default_width = 960;
+    const default_height = 540;
 
     pub fn init(allocator: *std.mem.Allocator, name: []const u8) View {
-        const view = View{
+        Window.open(name, default_width, default_height);
+        const screen_width = Window.getWidth();
+        const screen_height = Window.getHeight();
+        return View{
             .allocator = allocator,
             .cache = TextureCache.init(allocator.*),
             .camera = rl.Camera2D{
-                .offset = rl.Vector2{ .x = screen_width / 2, .y = screen_height / 2 },
+                .offset = rl.Vector2{ .x = @as(f32, @floatFromInt(screen_width)) / 2, .y = @as(f32, @floatFromInt(screen_height)) / 2 },
                 .target = rl.Vector2{ .x = 0, .y = 0 },
                 .rotation = 0,
                 .zoom = 1.0,
             },
         };
-
-        Window.open(name, screen_width, screen_height);
-
-        return view;
     }
 
     pub fn deinit(self: *View) void {
@@ -119,6 +117,10 @@ pub const View = struct {
             try list.append(.{ .Editor = .FileSave });
         }
 
+        if (Input.isKeyPressed(Input.KeyboardKey.tab)) {
+            try list.append(.{ .Editor = .ToggleColliderView });
+        }
+
         if (Input.isKeyPressed(Input.KeyboardKey.escape)) {
             try list.append(.Quit);
         }
@@ -161,6 +163,94 @@ pub const View = struct {
                     @intFromFloat(dest.height),
                     rl.Color.yellow,
                 );
+            }
+        }
+    }
+
+    fn drawDottedLine(a: rl.Vector2, b: rl.Vector2, color: rl.Color) void {
+        const segments: f32 = 8;
+        var i: f32 = 0;
+        while (i < segments) : (i += 2) {
+            const t1 = i / segments;
+            const t2 = (i + 1) / segments;
+            const p1 = rl.Vector2{ .x = std.math.lerp(a.x, b.x, t1), .y = std.math.lerp(a.y, b.y, t1) };
+            const p2 = rl.Vector2{ .x = std.math.lerp(a.x, b.x, t2), .y = std.math.lerp(a.y, b.y, t2) };
+            rl.drawLineEx(p1, p2, 1.0, color);
+        }
+    }
+
+    pub fn renderCorePrefab(self: *View, prefab: *const core.CorePrefab, dotted: bool) !void {
+        const color = if (dotted) rl.Color.gray else rl.Color.red;
+        for (prefab.colliders) |c| {
+            switch (c.shape) {
+                .Box => |b| {
+                    const hw = b.size.x / 2;
+                    const hh = b.size.y / 2;
+                    var corners = [_]rl.Vector2{
+                        .{ .x = -hw, .y = -hh },
+                        .{ .x = hw, .y = -hh },
+                        .{ .x = hw, .y = hh },
+                        .{ .x = -hw, .y = hh },
+                    };
+                    const rad = c.rotation.toRadians();
+                    const cos_t = @cos(rad);
+                    const sin_t = @sin(rad);
+                    for (corners, 0..) |*pt, _| {
+                        const x = pt.x;
+                        const y = pt.y;
+                        pt.* = rl.Vector2{
+                            .x = c.offset.x + x * cos_t - y * sin_t,
+                            .y = c.offset.y + x * sin_t + y * cos_t,
+                        };
+                    }
+                    var i: usize = 0;
+                    while (i < corners.len) : (i += 1) {
+                        const next = corners[(i + 1) % corners.len];
+                        if (dotted) drawDottedLine(corners[i], next, color) else rl.drawLineEx(corners[i], next, 1.0, color);
+                    }
+                },
+                .Circle => |circle| {
+                    rl.drawCircleLines(@intFromFloat(c.offset.x), @intFromFloat(c.offset.y), circle.radius, color);
+                },
+                .Segment => |s| {
+                    const a = rl.Vector2{ .x = c.offset.x + s.a.x, .y = c.offset.y + s.a.y };
+                    const b = rl.Vector2{ .x = c.offset.x + s.b.x, .y = c.offset.y + s.b.y };
+                    if (dotted) drawDottedLine(a, b, color) else rl.drawLineEx(a, b, 1.0, color);
+                },
+                .Polygon => |poly| {
+                    if (poly.vertices.len == 0) continue;
+                    var points = try self.allocator.alloc(rl.Vector2, poly.vertices.len);
+                    defer self.allocator.free(points);
+                    const rad = c.rotation.toRadians();
+                    const cos_t = @cos(rad);
+                    const sin_t = @sin(rad);
+                    for (poly.vertices, 0..) |v, idx| {
+                        const rx = v.x * cos_t - v.y * sin_t;
+                        const ry = v.x * sin_t + v.y * cos_t;
+                        points[idx] = rl.Vector2{ .x = c.offset.x + rx, .y = c.offset.y + ry };
+                    }
+                    var i: usize = 0;
+                    while (i < points.len) : (i += 1) {
+                        const next = points[(i + 1) % points.len];
+                        if (dotted) drawDottedLine(points[i], next, color) else rl.drawLineEx(points[i], next, 1.0, color);
+                    }
+                },
+                .Capsule => |cap| {
+                    const top = rl.Vector2{ .x = 0, .y = cap.half_height };
+                    const bottom = rl.Vector2{ .x = 0, .y = -cap.half_height };
+                    const rad = c.rotation.toRadians();
+                    const cos_t = @cos(rad);
+                    const sin_t = @sin(rad);
+                    const t = rl.Vector2{ .x = c.offset.x + top.x * cos_t - top.y * sin_t, .y = c.offset.y + top.x * sin_t + top.y * cos_t };
+                    const b = rl.Vector2{ .x = c.offset.x + bottom.x * cos_t - bottom.y * sin_t, .y = c.offset.y + bottom.x * sin_t + bottom.y * cos_t };
+                    if (dotted) {
+                        drawDottedLine(t, b, color);
+                    } else {
+                        rl.drawLineEx(t, b, 1.0, color);
+                    }
+                    rl.drawCircleLines(@intFromFloat(t.x), @intFromFloat(t.y), cap.radius, color);
+                    rl.drawCircleLines(@intFromFloat(b.x), @intFromFloat(b.y), cap.radius, color);
+                },
             }
         }
     }

--- a/src/shared/root.zig
+++ b/src/shared/root.zig
@@ -19,6 +19,8 @@ pub const core = @import("core/core.zig");
 pub const editor = @import("editor/editor.zig");
 pub const visual = @import("visual/visual.zig");
 pub const PrefabData = @import("prefab.zig").PrefabData;
+pub const Prefab = @import("prefab.zig").Prefab;
+pub const PrefabManifest = @import("prefab.zig").PrefabManifest;
 // ╚══════════════════════════════════════════════════════════════════╝
 
 // ╔══════════════════════════════ test ══════════════════════════════╗


### PR DESCRIPTION
## Summary
- define `PrefabManifest` describing prefab name and file references
- expose `PrefabManifest` in shared root
- load core and visual prefabs from manifest paths
- write manifest when saving prefabs

## Testing
- `zig build test` *(fails: unable to discover remote git server capabilities)*

------
https://chatgpt.com/codex/tasks/task_e_6881f431a1a08328a9add85e947e2a0e