### PR TITLE
Fix typos and ignore local zig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ zig-out/
 
 # kde
 .directory
+
+# local zig binaries
+zig-linux-x86_64-0.14.0*/
+zig-linux-x86_64-0.14.0.tar.xz

--- a/src/client/control.zig
+++ b/src/client/control.zig
@@ -63,7 +63,7 @@ pub const Control = struct {
             .state = State{},
         };
 
-        log.info("{s}-{s} v{s} started sucessfully", .{ core.name, name, core.version });
+        log.info("{s}-{s} v{s} started successfully", .{ core.name, name, core.version });
         log.info("All your starbase are belong to us", .{});
 
         return control;
@@ -74,7 +74,7 @@ pub const Control = struct {
         self.model.deinit();
         self.view.deinit();
 
-        log.info("stopped sucessfully", .{});
+        log.info("stopped successfully", .{});
     }
 
     pub fn update(self: *Control) void {

--- a/src/editor/control.zig
+++ b/src/editor/control.zig
@@ -99,14 +99,14 @@ pub const Control = struct {
             .cache = PrefabCache.init(gpa),
         };
 
-        log.info("{s}-{s} v{s} started sucessfully", .{ core.name, name, core.version });
+        log.info("{s}-{s} v{s} started successfully", .{ core.name, name, core.version });
         log.info("All your starbase are belong to us", .{});
 
         return control;
     }
 
     pub fn deinit(self: *Control) void {
-        log.info("stopped sucessfully", .{});
+        log.info("stopped successfully", .{});
 
         self.cache.deinit();
 

--- a/src/master/control.zig
+++ b/src/master/control.zig
@@ -39,7 +39,7 @@ pub const Control = struct {
 
         control.server.open(11111);
 
-        log.info("{s}-{s} v{s} started sucessfully", .{ core.name, name, core.version });
+        log.info("{s}-{s} v{s} started successfully", .{ core.name, name, core.version });
         log.info("All your starbase are belong to us", .{});
 
         return control;
@@ -48,7 +48,7 @@ pub const Control = struct {
     pub fn deinit(self: *Control) void {
         self.server.deinit();
 
-        log.info("stopped sucessfully", .{});
+        log.info("stopped successfully", .{});
     }
 
     pub fn update(self: *Control) void {

--- a/src/master/quadtree.zig
+++ b/src/master/quadtree.zig
@@ -209,9 +209,9 @@ const Neightbours = struct {
 pub const QuadNode = struct {
     pub const max_depth = 10;
     pub const cells_per_axis: i32 = 1 << max_depth;
-    pub const merge_threshhold = 30;
+    pub const merge_threshold = 30;
     pub const merge_time = 10;
-    pub const split_threshhold = 50;
+    pub const split_threshold = 50;
 
     gpa: *std.mem.Allocator,
     owner: ?ServerId,
@@ -221,7 +221,7 @@ pub const QuadNode = struct {
     parent: ?*QuadNode,
     quadrant_in_parent: ?Quadrant,
     children: ?[]*QuadNode,
-    below_threshhold_since: i64,
+    below_threshold_since: i64,
 
     fn init(gpa: *std.mem.Allocator, rectangle: Rect, depth: u8) QuadNode {
         return QuadNode{
@@ -233,7 +233,7 @@ pub const QuadNode = struct {
             .parent = null,
             .quadrant_in_parent = null,
             .children = null,
-            .below_threshhold_since = std.time.timestamp(),
+            .below_threshold_since = std.time.timestamp(),
         };
     }
 
@@ -268,11 +268,11 @@ pub const QuadNode = struct {
             child.* = QuadNode{
                 .gpa = alloc,
                 .owner = null,
-                .pressure = split_threshhold - 1,
+                .pressure = split_threshold - 1,
                 .depth = next_depth,
                 .rectangle = bounds[i],
                 .children = null,
-                .below_threshhold_since = std.time.timestamp(),
+                .below_threshold_since = std.time.timestamp(),
                 .parent = self,
                 .quadrant_in_parent = Quadrant.fromInt(@intCast(i)),
             };
@@ -292,7 +292,7 @@ pub const QuadNode = struct {
         self.gpa.free(self.children.?);
         self.children = null;
         self.pressure = totalPressure;
-        self.below_threshhold_since = std.time.timestamp();
+        self.below_threshold_since = std.time.timestamp();
     }
 
     pub fn isLeaf(self: *QuadNode) bool {
@@ -314,7 +314,7 @@ pub const QuadNode = struct {
         } else {
             if (self.depth >= max_depth) return;
 
-            if (self.pressure >= split_threshhold) {
+            if (self.pressure >= split_threshold) {
                 self.split(); // create children
 
                 if (self.children) |children| {
@@ -323,19 +323,19 @@ pub const QuadNode = struct {
                         child.owner = chosen.id;
                     }
                 }
-            } else if (self.pressure > merge_threshhold) {
-                self.below_threshhold_since = now;
+            } else if (self.pressure > merge_threshold) {
+                self.below_threshold_since = now;
             }
         }
 
-        if (now - self.below_threshhold_since > merge_time) {
+        if (now - self.below_threshold_since > merge_time) {
             if (self.children) |children| {
                 for (children) |child| {
                     if (!child.isLeaf()) {
                         return;
                     }
-                    std.log.info("time: {}", .{now - child.below_threshhold_since});
-                    if (!(now - child.below_threshhold_since > merge_time)) {
+                    std.log.info("time: {}", .{now - child.below_threshold_since});
+                    if (!(now - child.below_threshold_since > merge_time)) {
                         return;
                     }
                 }

--- a/src/master/server_registry.zig
+++ b/src/master/server_registry.zig
@@ -20,7 +20,7 @@ const testing = std.testing;
 // -------------------------
 
 // ---------- starmont --------
-const ServerId = @import("extra").network.SeverId;
+const ServerId = @import("extra").network.ServerId;
 const ServerInfo = @import("extra").network.ServerInfo;
 // ----------------------------
 

--- a/src/server/control.zig
+++ b/src/server/control.zig
@@ -43,7 +43,7 @@ pub const Control = struct {
 
         control.server.open(0);
 
-        log.info("{s}-{s} v{s} started sucessfully", .{ core.name, name, core.version });
+        log.info("{s}-{s} v{s} started successfully", .{ core.name, name, core.version });
         log.info("all your starbase are belong to us", .{});
 
         return control;
@@ -53,7 +53,7 @@ pub const Control = struct {
         self.server.deinit();
         self.model.deinit();
 
-        log.info("stopped sucessfully", .{});
+        log.info("stopped successfully", .{});
     }
 
     pub fn update(self: *Control) void {
@@ -106,7 +106,7 @@ pub const Control = struct {
                             }
                         },
                         .SnapshotRequest => {
-                            std.debug.print("requsted snapshot\n", .{});
+                            std.debug.print("requested snapshot\n", .{});
                             //self.sendSnapshot();
                         },
                         else => @panic("received unexpected message"),


### PR DESCRIPTION
## Summary
- fix typo in ServerRegistry import
- correct spelling of success logs and requested snapshot
- rename quadtree threshold fields

------
https://chatgpt.com/codex/tasks/task_e_6888652bc2408328b93f7a9bcbc728ea